### PR TITLE
Migrate banner tests to pbs on aws

### DIFF
--- a/src/test/java/appium/inAppBidding/InAppBaseTest.java
+++ b/src/test/java/appium/inAppBidding/InAppBaseTest.java
@@ -68,7 +68,7 @@ public class InAppBaseTest {
         env.logValidator.clearLogs();
     }
 
-    @BeforeMethod(groups = {"serverBased"})
+    @BeforeMethod(groups = {"serverBased", "serverBased-ios","smoke", "android", "ios", "exec", "requests"})
     public void setupMethodBMP(ITestContext itc) throws InterruptedException {
         if (!env.homePage.isSearchFieldDisplayed()) {
             env.homePage.relaunchApp();
@@ -121,7 +121,7 @@ public class InAppBaseTest {
     }
 
     public void initEventHandler() {
-        System.out.println("Log validator: "+env.logValidator.getLogs());
+//        System.out.println("Log validator: "+env.logValidator.getLogs());
         eventHandler = new OMSDKEventHandler(env.bmp.getHar());
     }
 

--- a/src/test/java/appium/inAppBidding/InAppBaseTest.java
+++ b/src/test/java/appium/inAppBidding/InAppBaseTest.java
@@ -34,13 +34,13 @@ public class InAppBaseTest {
     public OMSDKEventHandler eventHandler;
 
 
-    @BeforeTest(groups = {"smoke", "android", "ios", "exec", "requests"})
+//    @BeforeTest(groups = {"smoke", "android", "ios", "exec", "requests"})
     public void setupMock(ITestContext itc) throws IOException {
         System.out.println(itc.getName());
         setup(itc, TestEnvironment.INSPECTORS_MOCK_SERVER);
     }
 
-    @BeforeTest(groups = {"serverBased", "serverBased-ios"})
+    @BeforeTest(groups = {"serverBased", "serverBased-ios","smoke", "android", "ios", "exec", "requests"})
     public void setupBMP(ITestContext itc) throws IOException {
         System.out.println(itc.getName());
         setup(itc, TestEnvironment.INSPECTORS_MOB_PROXY);
@@ -56,7 +56,7 @@ public class InAppBaseTest {
     }
 
 
-    @BeforeMethod(groups = {"smoke", "android", "ios", "exec", "requests"})
+//    @BeforeMethod(groups = {"smoke", "android", "ios", "exec", "requests"})
     public void setupMethodMock(ITestContext itc) throws InterruptedException {
         if (!env.homePage.isSearchFieldDisplayed()) {
             env.homePage.relaunchApp();
@@ -122,7 +122,7 @@ public class InAppBaseTest {
 
     public void initEventHandler() {
         System.out.println("Log validator: "+env.logValidator.getLogs());
-        eventHandler = new OMSDKEventHandler(env.logValidator);
+        eventHandler = new OMSDKEventHandler(env.bmp.getHar());
     }
 
     private void setup(ITestContext itc, Set<TestEnvironment.TrafficInspectorKind> trafficInsprctors) throws IOException {

--- a/src/test/java/appium/inAppBidding/InAppBaseTest.java
+++ b/src/test/java/appium/inAppBidding/InAppBaseTest.java
@@ -150,7 +150,7 @@ public class InAppBaseTest {
         }
         if (prebidAd.contains("MoPub")) {
             env.waitForEvent(InAppBiddingTestEnvironment.InAppBiddingEvents.MOPUB_AD, 1, 60);
-            env.waitForEvent(InAppBiddingTestEnvironment.InAppBiddingEvents.MOPUB_IMP, 1, 60);
+//            env.waitForEvent(InAppBiddingTestEnvironment.InAppBiddingEvents.MOPUB_IMP, 1, 60);
         }
         if (prebidAd.contains("AdMob")) {
             if (isPlatformIOS) {

--- a/src/test/java/appium/inAppBidding/InAppBiddingBannerTests.java
+++ b/src/test/java/appium/inAppBidding/InAppBiddingBannerTests.java
@@ -40,7 +40,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         env.validateEventRequest(InAppBiddingEvents.AUCTION, validAuctionRequest);
         env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 30);
-//        checkGamOrMoPubEvents(prebidAd);
+        checkGamOrMoPubEvents(prebidAd);
         System.out.println(validAuctionRequest);
         env.homePage.clickBack();
 
@@ -89,21 +89,21 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         System.out.println(InAppBiddingEvents.GAM_G_DOUBLECLICK);
 
-//        if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_GAM_AD)) {
-//            if (isPlatformIOS) {
-//                env.waitForEvent(InAppBiddingEvents.GAM_GAMPAD, 1, 10);
-//            } else {
-//                env.waitForEvent(InAppBiddingEvents.GAM_G_DOUBLECLICK, 1, 10);
-//            }
-//        } else if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_MOPUB)) {
-//            env.waitForEvent(InAppBiddingEvents.MOPUB_AD, 1, 10);
-//            env.waitForEvent(InAppBiddingEvents.MOPUB_IMP, 1, 10);
-//        } else if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_ADMOB)) {
-//            if (isPlatformIOS) {
-//                env.waitForEvent(InAppBiddingEvents.ADMOB_MADS_GMA, 1, 10);
-//            }
-//            env.waitForEvent(InAppBiddingEvents.ADMOB_PAGEAD_INTERACTION, 1, 10);
-//        }
+        if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_GAM_AD)) {
+            if (isPlatformIOS) {
+                env.waitForEvent(InAppBiddingEvents.GAM_GAMPAD, 1, 10);
+            } else {
+                env.waitForEvent(InAppBiddingEvents.GAM_G_DOUBLECLICK, 1, 10);
+            }
+        } else if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_MOPUB)) {
+            env.waitForEvent(InAppBiddingEvents.MOPUB_AD, 1, 10);
+            env.waitForEvent(InAppBiddingEvents.MOPUB_IMP, 1, 10);
+        } else if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_ADMOB)) {
+            if (isPlatformIOS) {
+                env.waitForEvent(InAppBiddingEvents.ADMOB_MADS_GMA, 1, 10);
+            }
+            env.waitForEvent(InAppBiddingEvents.ADMOB_PAGEAD_INTERACTION, 1, 10);
+        }
 
         env.homePage.clickBack();
     }

--- a/src/test/java/appium/inAppBidding/InAppBiddingBannerTests.java
+++ b/src/test/java/appium/inAppBidding/InAppBiddingBannerTests.java
@@ -40,7 +40,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         env.validateEventRequest(InAppBiddingEvents.AUCTION, validAuctionRequest);
         env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 30);
-        checkGamOrMoPubEvents(prebidAd);
+//        checkGamOrMoPubEvents(prebidAd);
         System.out.println(validAuctionRequest);
         env.homePage.clickBack();
 
@@ -89,21 +89,21 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         System.out.println(InAppBiddingEvents.GAM_G_DOUBLECLICK);
 
-        if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_GAM_AD)) {
-            if (isPlatformIOS) {
-                env.waitForEvent(InAppBiddingEvents.GAM_GAMPAD, 1, 10);
-            } else {
-                env.waitForEvent(InAppBiddingEvents.GAM_G_DOUBLECLICK, 1, 10);
-            }
-        } else if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_MOPUB)) {
-            env.waitForEvent(InAppBiddingEvents.MOPUB_AD, 1, 10);
-            env.waitForEvent(InAppBiddingEvents.MOPUB_IMP, 1, 10);
-        } else if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_ADMOB)) {
-            if (isPlatformIOS) {
-                env.waitForEvent(InAppBiddingEvents.ADMOB_MADS_GMA, 1, 10);
-            }
-            env.waitForEvent(InAppBiddingEvents.ADMOB_PAGEAD_INTERACTION, 1, 10);
-        }
+//        if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_GAM_AD)) {
+//            if (isPlatformIOS) {
+//                env.waitForEvent(InAppBiddingEvents.GAM_GAMPAD, 1, 10);
+//            } else {
+//                env.waitForEvent(InAppBiddingEvents.GAM_G_DOUBLECLICK, 1, 10);
+//            }
+//        } else if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_MOPUB)) {
+//            env.waitForEvent(InAppBiddingEvents.MOPUB_AD, 1, 10);
+//            env.waitForEvent(InAppBiddingEvents.MOPUB_IMP, 1, 10);
+//        } else if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_ADMOB)) {
+//            if (isPlatformIOS) {
+//                env.waitForEvent(InAppBiddingEvents.ADMOB_MADS_GMA, 1, 10);
+//            }
+//            env.waitForEvent(InAppBiddingEvents.ADMOB_PAGEAD_INTERACTION, 1, 10);
+//        }
 
         env.homePage.clickBack();
     }
@@ -241,7 +241,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
         // RUN TEST SCENARIO
         InAppBiddingAdPageImpl bannerPage = env.homePage.goToAd(bannerAds);
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 30);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 30);
 
         bannerPage.isAdDisplayed();
 
@@ -252,7 +252,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         env.homePage.clickBack();
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 30);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 30);
         // CHECK OM EVENTS
         initEventHandler();
         assertTrue(eventHandler.checkSessionsCount(1));
@@ -267,15 +267,15 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
         // RUN TEST SCENARIO
         InAppBiddingAdPageImpl bannerPage = env.homePage.goToAd(BANNER_320x50_ADMOB);
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 10);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 10);
 
         bannerPage.clickReloadButton();
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 2, 10);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 2, 10);
 
         env.homePage.clickBack();
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 2, 50);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 2, 50);
         // CHECK OM EVENTS
         initEventHandler();
         assertTrue(eventHandler.checkSessionsCount(2));
@@ -299,7 +299,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
         // RUN TEST SCENARIO
         InAppBiddingAdPageImpl bannerPage = env.homePage.goToAd(BANNER_320x50_ADMOB);
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 30);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 30);
 
         bannerPage.clickBanner();
 
@@ -313,7 +313,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         env.homePage.clickBack();
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 30);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 30);
         // CHECK OM EVENTS
         initEventHandler();
         assertTrue(eventHandler.checkSessionsCount(1));
@@ -340,7 +340,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         bannerPage.isAdDisplayed();
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 10);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 10);
 
         env.homePage.runAppInBackground(5);
 
@@ -350,7 +350,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         env.homePage.clickBack();
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 10);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 10);
 
         // CHECK OM EVENTS
         initEventHandler();
@@ -376,13 +376,13 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         checkLoadDelegates();
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 30);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 30);
 
         bannerPage.performScrollUpAndDown();
 
         env.homePage.clickBack();
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 30);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 30);
 
         initEventHandler();
         assertTrue(eventHandler.checkSessionsCount(1));
@@ -495,14 +495,14 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         checkLoadDelegates();
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 10);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 10);
 
         env.waitForEvent(InAppBiddingEvents.AUCTION, expectedEventCount, autoRefreshDelay * expectedEventCount);
         env.waitForEvent(InAppBiddingEvents.WIN_PREBID, expectedEventCount, autoRefreshDelay * expectedEventCount);
 
         env.homePage.clickBack();
 
-        env.waitForOMEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, expectedEventCount, 30);
+        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, expectedEventCount, 30);
         // CHECK OM EVENTS
         initEventHandler();
         assertTrue(eventHandler.checkSessionsCount(expectedEventCount));

--- a/src/test/java/appium/inAppBidding/InAppBiddingBannerTests.java
+++ b/src/test/java/appium/inAppBidding/InAppBiddingBannerTests.java
@@ -32,35 +32,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
     }
 
-//    @Test(groups = {"serverBased"}, dataProvider = "serverBasedBanner", dataProviderClass = InAppDataProviders.class)
-//    public void testAuctionRequestServerBased(String prebidAd) throws TimeoutException, InterruptedException {
-//        initValidTemplatesJson(prebidAd);
-//        env.homePage.goToAd(prebidAd);
-//        env.waitForEvent(InAppBiddingEvents.AUCTION, 1, 60);
-//
-//        env.validateEventRequest(InAppBiddingEvents.AUCTION, validAuctionRequest);
-//        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 30);
-//        checkGamOrMoPubEvents(prebidAd);
-//        System.out.println(validAuctionRequest);
-//        env.homePage.clickBack();
-//
-//        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 30);
-//        // CHECK OM EVENTS
-//        OMSDKEventHandler eventHandler = new OMSDKEventHandler(env.bmp.getHar());
-//        assertTrue(eventHandler.checkSessionsCount(1));
-//        OMSDKSessionDescriptor session = eventHandler.getFirstSession();
-//        // It could be 'obstructed' when webBrowser opened or 'clipped', or 'notFound' for android
-//        String[] reasons = {OMSDKSessionDescriptor.EVENT_VALUE.OBSTRUCTED, OMSDKSessionDescriptor.EVENT_VALUE.CLIPPED, OMSDKSessionDescriptor.EVENT_VALUE.NOT_FOUND};
-//
-//
-//        session.checkOMBaseEvents(platformName);
-//        // TODO Why to checkViewability
-////        if (isPlatformIOS) {
-////            session.checkHideAndRestoreViewabilityWithReasons(reasons);
-////        }
-//    }
-
-    @Test(groups = {"serverBased"}, dataProvider = "serverBasedBanner", dataProviderClass = InAppDataProviders.class)
+    @Test(groups = {"requests"}, dataProvider = "serverBasedBanner", dataProviderClass = InAppDataProviders.class)
     public void testVersionParametersInRequest(String prebidAd) throws InterruptedException, TimeoutException {
         env.homePage.goToAd(prebidAd);
 
@@ -71,7 +43,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
         RequestValidator.checkVersionParametersFromRequest(env.bmp.getHar(), ver, version, omidpv, displaymanagerver);
     }
 
-    @Test(groups = {"serverBased"}, dataProvider = "noBids", dataProviderClass = InAppDataProviders.class)
+    @Test(groups = {"requests"}, dataProvider = "noBids", dataProviderClass = InAppDataProviders.class)
     public void testAuctionRequestNoBidsAd(String prebidAd) throws TimeoutException, InterruptedException {
         String noBidAd;
         initValidTemplatesJson(prebidAd);
@@ -89,7 +61,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         System.out.println(InAppBiddingEvents.GAM_G_DOUBLECLICK);
 
-        /*if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_GAM_AD)) {
+        if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_GAM_AD)) {
             if (isPlatformIOS) {
                 env.waitForEvent(InAppBiddingEvents.GAM_GAMPAD, 1, 10);
             } else {
@@ -103,7 +75,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
                 env.waitForEvent(InAppBiddingEvents.ADMOB_MADS_GMA, 1, 10);
             }
             env.waitForEvent(InAppBiddingEvents.ADMOB_PAGEAD_INTERACTION, 1, 10);
-        }*/
+        }
 
         env.homePage.clickBack();
     }
@@ -249,7 +221,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
             env.homePage.rotateLandscape();
             env.homePage.rotatePortrait();
         }
-
+        checkGamOrMoPubEvents(bannerAds);
         env.homePage.clickBack();
 
         env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 30);

--- a/src/test/java/appium/inAppBidding/InAppBiddingBannerTests.java
+++ b/src/test/java/appium/inAppBidding/InAppBiddingBannerTests.java
@@ -32,33 +32,33 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
     }
 
-    @Test(groups = {"serverBased"}, dataProvider = "serverBasedBanner", dataProviderClass = InAppDataProviders.class)
-    public void testAuctionRequestServerBased(String prebidAd) throws TimeoutException, InterruptedException {
-        initValidTemplatesJson(prebidAd);
-        env.homePage.goToAd(prebidAd);
-        env.waitForEvent(InAppBiddingEvents.AUCTION, 1, 60);
-
-        env.validateEventRequest(InAppBiddingEvents.AUCTION, validAuctionRequest);
-        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 30);
-        checkGamOrMoPubEvents(prebidAd);
-        System.out.println(validAuctionRequest);
-        env.homePage.clickBack();
-
-        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 30);
-        // CHECK OM EVENTS
-        OMSDKEventHandler eventHandler = new OMSDKEventHandler(env.bmp.getHar());
-        assertTrue(eventHandler.checkSessionsCount(1));
-        OMSDKSessionDescriptor session = eventHandler.getFirstSession();
-        // It could be 'obstructed' when webBrowser opened or 'clipped', or 'notFound' for android
-        String[] reasons = {OMSDKSessionDescriptor.EVENT_VALUE.OBSTRUCTED, OMSDKSessionDescriptor.EVENT_VALUE.CLIPPED, OMSDKSessionDescriptor.EVENT_VALUE.NOT_FOUND};
-
-
-        session.checkOMBaseEvents(platformName);
-        // TODO Why to checkViewability
-//        if (isPlatformIOS) {
-//            session.checkHideAndRestoreViewabilityWithReasons(reasons);
-//        }
-    }
+//    @Test(groups = {"serverBased"}, dataProvider = "serverBasedBanner", dataProviderClass = InAppDataProviders.class)
+//    public void testAuctionRequestServerBased(String prebidAd) throws TimeoutException, InterruptedException {
+//        initValidTemplatesJson(prebidAd);
+//        env.homePage.goToAd(prebidAd);
+//        env.waitForEvent(InAppBiddingEvents.AUCTION, 1, 60);
+//
+//        env.validateEventRequest(InAppBiddingEvents.AUCTION, validAuctionRequest);
+//        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_START, 1, 30);
+//        checkGamOrMoPubEvents(prebidAd);
+//        System.out.println(validAuctionRequest);
+//        env.homePage.clickBack();
+//
+//        env.bmp.waitForEvent(OMSDKSessionDescriptor.EVENT_TYPE.SESSION_FINISH, 1, 30);
+//        // CHECK OM EVENTS
+//        OMSDKEventHandler eventHandler = new OMSDKEventHandler(env.bmp.getHar());
+//        assertTrue(eventHandler.checkSessionsCount(1));
+//        OMSDKSessionDescriptor session = eventHandler.getFirstSession();
+//        // It could be 'obstructed' when webBrowser opened or 'clipped', or 'notFound' for android
+//        String[] reasons = {OMSDKSessionDescriptor.EVENT_VALUE.OBSTRUCTED, OMSDKSessionDescriptor.EVENT_VALUE.CLIPPED, OMSDKSessionDescriptor.EVENT_VALUE.NOT_FOUND};
+//
+//
+//        session.checkOMBaseEvents(platformName);
+//        // TODO Why to checkViewability
+////        if (isPlatformIOS) {
+////            session.checkHideAndRestoreViewabilityWithReasons(reasons);
+////        }
+//    }
 
     @Test(groups = {"serverBased"}, dataProvider = "serverBasedBanner", dataProviderClass = InAppDataProviders.class)
     public void testVersionParametersInRequest(String prebidAd) throws InterruptedException, TimeoutException {
@@ -89,7 +89,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
 
         System.out.println(InAppBiddingEvents.GAM_G_DOUBLECLICK);
 
-        if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_GAM_AD)) {
+        /*if (prebidAd.equalsIgnoreCase(BANNER_320x50_NO_BID_GAM_AD)) {
             if (isPlatformIOS) {
                 env.waitForEvent(InAppBiddingEvents.GAM_GAMPAD, 1, 10);
             } else {
@@ -103,7 +103,7 @@ public class InAppBiddingBannerTests extends InAppBaseTest {
                 env.waitForEvent(InAppBiddingEvents.ADMOB_MADS_GMA, 1, 10);
             }
             env.waitForEvent(InAppBiddingEvents.ADMOB_PAGEAD_INTERACTION, 1, 10);
-        }
+        }*/
 
         env.homePage.clickBack();
     }

--- a/src/test/resources/appium/inAppBidding/inAppBidding_Android.xml
+++ b/src/test/resources/appium/inAppBidding/inAppBidding_Android.xml
@@ -6,49 +6,49 @@
     <parameter name="prebidTestPlatform" value="Android-Server"/>
     <parameter name="prebidServerKind" value="Prebid"/>
     <parameter name="locatorType" value="text"/>
-<!--    <test verbose="3" name="InApp_Bidding Android Server Based">-->
-<!--        <groups>-->
-<!--            <run>-->
-<!--                <include name="serverBased"/>-->
-<!--            </run>-->
-<!--        </groups>-->
-<!--        <classes>-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>&ndash;&gt;-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>&ndash;&gt;-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>&ndash;&gt;-->
-<!--            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>-->
-<!--            &lt;!&ndash; Currently native ads is not supported               &ndash;&gt;-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>&ndash;&gt;-->
-<!--        </classes>-->
-<!--    </test>-->
-<!--    <test verbose="3" name="InApp_Bidding Android Custom Requests">-->
-<!--        <groups>-->
-<!--            <run>-->
-<!--                <include name="USPrivacy"/>-->
-<!--                <include name="TCFv1"/>-->
-<!--                <include name="CustomOpenRTB"/>-->
-<!--                <include name="LiveRampATS"/>-->
-<!--            </run>-->
-<!--        </groups>-->
-<!--        <classes>-->
-<!--            <class name="appium.inAppBidding.InAppBiddingCustomRequestTests"/>-->
-<!--        </classes>-->
-<!--    </test>-->
-<!--    <test verbose="3" name="InApp_Bidding Android Smoke [Smoke] [MOCK]]">-->
-<!--        <groups>-->
-<!--            <run>-->
-<!--                <include name="android"/>-->
-<!--                <include name="smoke"/>-->
-<!--            </run>-->
-<!--        </groups>-->
-<!--        <classes>-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>&ndash;&gt;-->
-<!--            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>&ndash;&gt;-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>&ndash;&gt;-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>&ndash;&gt;-->
-<!--        </classes>-->
-<!--    </test>-->
+    <test verbose="3" name="InApp_Bidding Android Server Based">
+        <groups>
+            <run>
+                <include name="serverBased"/>
+            </run>
+        </groups>
+        <classes>
+<!--            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>-->
+            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>
+            <!-- Currently native ads is not supported               -->
+<!--            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>-->
+        </classes>
+    </test>
+    <test verbose="3" name="InApp_Bidding Android Custom Requests">
+        <groups>
+            <run>
+                <include name="USPrivacy"/>
+                <include name="TCFv1"/>
+                <include name="CustomOpenRTB"/>
+                <include name="LiveRampATS"/>
+            </run>
+        </groups>
+        <classes>
+            <class name="appium.inAppBidding.InAppBiddingCustomRequestTests"/>
+        </classes>
+    </test>
+    <test verbose="3" name="InApp_Bidding Android Smoke [Smoke] [MOCK]]">
+        <groups>
+            <run>
+                <include name="android"/>
+                <include name="smoke"/>
+            </run>
+        </groups>
+        <classes>
+<!--            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>-->
+            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>
+<!--            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>-->
+        </classes>
+    </test>
     <test verbose="3" name="InApp_Bidding Android Requests [OM, Auction, Events, OpenRTB] [MOCK]">
         <groups>
             <run>

--- a/src/test/resources/appium/inAppBidding/inAppBidding_Android.xml
+++ b/src/test/resources/appium/inAppBidding/inAppBidding_Android.xml
@@ -21,47 +21,47 @@
 <!--            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>-->
         </classes>
     </test>
-    <test verbose="3" name="InApp_Bidding Android Custom Requests">
-        <groups>
-            <run>
-                <include name="USPrivacy"/>
-                <include name="TCFv1"/>
-                <include name="CustomOpenRTB"/>
-                <include name="LiveRampATS"/>
-            </run>
-        </groups>
-        <classes>
-            <class name="appium.inAppBidding.InAppBiddingCustomRequestTests"/>
-        </classes>
-    </test>
-    <test verbose="3" name="InApp_Bidding Android Smoke [Smoke] [MOCK]]">
-        <groups>
-            <run>
-                <include name="android"/>
-                <include name="smoke"/>
-            </run>
-        </groups>
-        <classes>
-<!--            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>-->
-            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>
-<!--            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>-->
-<!--            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>-->
-<!--            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>-->
-        </classes>
-    </test>
-    <test verbose="3" name="InApp_Bidding Android Requests [OM, Auction, Events, OpenRTB] [MOCK]">
-        <groups>
-            <run>
-                <include name="requests"/>
-                <include name="requests-Android"/>
-            </run>
-        </groups>
-        <classes>
-<!--            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>-->
-<!--            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>-->
-            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>
-<!--            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>-->
-<!--            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>-->
-        </classes>
-    </test>
+<!--    <test verbose="3" name="InApp_Bidding Android Custom Requests">-->
+<!--        <groups>-->
+<!--            <run>-->
+<!--                <include name="USPrivacy"/>-->
+<!--                <include name="TCFv1"/>-->
+<!--                <include name="CustomOpenRTB"/>-->
+<!--                <include name="LiveRampATS"/>-->
+<!--            </run>-->
+<!--        </groups>-->
+<!--        <classes>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingCustomRequestTests"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test verbose="3" name="InApp_Bidding Android Smoke [Smoke] [MOCK]]">-->
+<!--        <groups>-->
+<!--            <run>-->
+<!--                <include name="android"/>-->
+<!--                <include name="smoke"/>-->
+<!--            </run>-->
+<!--        </groups>-->
+<!--        <classes>-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>&ndash;&gt;-->
+<!--            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>&ndash;&gt;-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test verbose="3" name="InApp_Bidding Android Requests [OM, Auction, Events, OpenRTB] [MOCK]">-->
+<!--        <groups>-->
+<!--            <run>-->
+<!--                <include name="requests"/>-->
+<!--                <include name="requests-Android"/>-->
+<!--            </run>-->
+<!--        </groups>-->
+<!--        <classes>-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>&ndash;&gt;-->
+<!--            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>&ndash;&gt;-->
+<!--        </classes>-->
+<!--    </test>-->
 </suite>

--- a/src/test/resources/appium/inAppBidding/inAppBidding_Android.xml
+++ b/src/test/resources/appium/inAppBidding/inAppBidding_Android.xml
@@ -6,19 +6,62 @@
     <parameter name="prebidTestPlatform" value="Android-Server"/>
     <parameter name="prebidServerKind" value="Prebid"/>
     <parameter name="locatorType" value="text"/>
-    <test verbose="3" name="InApp_Bidding Android Server Based">
+<!--    <test verbose="3" name="InApp_Bidding Android Server Based">-->
+<!--        <groups>-->
+<!--            <run>-->
+<!--                <include name="serverBased"/>-->
+<!--            </run>-->
+<!--        </groups>-->
+<!--        <classes>-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>&ndash;&gt;-->
+<!--            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>-->
+<!--            &lt;!&ndash; Currently native ads is not supported               &ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>&ndash;&gt;-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test verbose="3" name="InApp_Bidding Android Custom Requests">-->
+<!--        <groups>-->
+<!--            <run>-->
+<!--                <include name="USPrivacy"/>-->
+<!--                <include name="TCFv1"/>-->
+<!--                <include name="CustomOpenRTB"/>-->
+<!--                <include name="LiveRampATS"/>-->
+<!--            </run>-->
+<!--        </groups>-->
+<!--        <classes>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingCustomRequestTests"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test verbose="3" name="InApp_Bidding Android Smoke [Smoke] [MOCK]]">-->
+<!--        <groups>-->
+<!--            <run>-->
+<!--                <include name="android"/>-->
+<!--                <include name="smoke"/>-->
+<!--            </run>-->
+<!--        </groups>-->
+<!--        <classes>-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>&ndash;&gt;-->
+<!--            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>&ndash;&gt;-->
+<!--        </classes>-->
+<!--    </test>-->
+    <test verbose="3" name="InApp_Bidding Android Requests [OM, Auction, Events, OpenRTB] [MOCK]">
         <groups>
             <run>
-                <include name="serverBased"/>
+                <include name="requests"/>
+                <include name="requests-Android"/>
             </run>
         </groups>
         <classes>
-            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>
-            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>
-            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>
-            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>
-            <!-- Currently native ads is not supported               -->
 <!--            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>-->
+            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>
+<!--            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>-->
         </classes>
     </test>
 </suite>

--- a/src/test/resources/appium/inAppBidding/inAppBidding_Android.xml
+++ b/src/test/resources/appium/inAppBidding/inAppBidding_Android.xml
@@ -6,21 +6,7 @@
     <parameter name="prebidTestPlatform" value="Android-Server"/>
     <parameter name="prebidServerKind" value="Prebid"/>
     <parameter name="locatorType" value="text"/>
-    <test verbose="3" name="InApp_Bidding Android Server Based">
-        <groups>
-            <run>
-                <include name="serverBased"/>
-            </run>
-        </groups>
-        <classes>
-<!--            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>-->
-<!--            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>-->
-<!--            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>-->
-            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>
-            <!-- Currently native ads is not supported               -->
-<!--            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>-->
-        </classes>
-    </test>
+
 <!--    <test verbose="3" name="InApp_Bidding Android Custom Requests">-->
 <!--        <groups>-->
 <!--            <run>-->
@@ -34,34 +20,34 @@
 <!--            <class name="appium.inAppBidding.InAppBiddingCustomRequestTests"/>-->
 <!--        </classes>-->
 <!--    </test>-->
-<!--    <test verbose="3" name="InApp_Bidding Android Smoke [Smoke] [MOCK]]">-->
-<!--        <groups>-->
-<!--            <run>-->
-<!--                <include name="android"/>-->
-<!--                <include name="smoke"/>-->
-<!--            </run>-->
-<!--        </groups>-->
-<!--        <classes>-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>&ndash;&gt;-->
-<!--            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>&ndash;&gt;-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>&ndash;&gt;-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>&ndash;&gt;-->
-<!--        </classes>-->
-<!--    </test>-->
-<!--    <test verbose="3" name="InApp_Bidding Android Requests [OM, Auction, Events, OpenRTB] [MOCK]">-->
-<!--        <groups>-->
-<!--            <run>-->
-<!--                <include name="requests"/>-->
-<!--                <include name="requests-Android"/>-->
-<!--            </run>-->
-<!--        </groups>-->
-<!--        <classes>-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>&ndash;&gt;-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>&ndash;&gt;-->
-<!--            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>&ndash;&gt;-->
-<!--&lt;!&ndash;            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>&ndash;&gt;-->
-<!--        </classes>-->
-<!--    </test>-->
+    <test verbose="3" name="InApp_Bidding Android Smoke [Smoke] [MOCK]]">
+        <groups>
+            <run>
+                <include name="android"/>
+                <include name="smoke"/>
+            </run>
+        </groups>
+        <classes>
+<!--            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>-->
+            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>
+<!--            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>-->
+        </classes>
+    </test>
+    <test verbose="3" name="InApp_Bidding Android Requests [OM, Auction, Events, OpenRTB] [MOCK]">
+        <groups>
+            <run>
+                <include name="requests"/>
+                <include name="requests-Android"/>
+            </run>
+        </groups>
+        <classes>
+<!--            <class name="appium.inAppBidding.InAppBiddingNativeTests"/>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>-->
+            <class name="appium.inAppBidding.InAppBiddingBannerTests"/>
+<!--            <class name="appium.inAppBidding.InAppBiddingMraidTests"/>-->
+<!--            <class name="appium.inAppBidding.InAppBiddingVideoTests"/>-->
+        </classes>
+    </test>
 </suite>

--- a/src/test/resources/appium/inAppBidding/inAppBidding_iOS.xml
+++ b/src/test/resources/appium/inAppBidding/inAppBidding_iOS.xml
@@ -22,4 +22,47 @@
             <class name="appium.inAppBidding.InAppBiddingVideoTests"/>
 		</classes>
 	</test>
+	<test verbose="3" name="InApp_Bidding iOS Custom Requests">
+		<groups>
+			<run>
+				<include name="USPrivacy"/>
+				<include name="TCFv1"/>
+				<include name="CustomOpenRTB"/>
+				<include name="LiveRampATS"/>
+			</run>
+		</groups>
+		<classes>
+			<class name="appium.inAppBidding.InAppBiddingCustomRequestTests"/>
+		</classes>
+	</test>
+	<test verbose="3" name="InApp_Bidding iOS Smoke [Smoke] [MOCK]]">
+		<groups>
+			<run>
+				<include name="ios"/>
+				<include name="smoke"/>
+			</run>
+		</groups>
+		<classes>
+			<class name="appium.inAppBidding.InAppBiddingNativeTests"/>
+			<class name="appium.inAppBidding.InAppBiddingBannerTests"/>
+			<class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>
+			<class name="appium.inAppBidding.InAppBiddingMraidTests"/>
+			<class name="appium.inAppBidding.InAppBiddingVideoTests"/>
+		</classes>
+	</test>
+	<test verbose="3" name="InApp_Bidding iOS Requests [OM, Auction, Events, OpenRTB] [MOCK]">
+		<groups>
+			<run>
+				<include name="requests"/>
+				<include name="requests-iOS"/>
+			</run>
+		</groups>
+		<classes>
+			<class name="appium.inAppBidding.InAppBiddingNativeTests"/>
+			<class name="appium.inAppBidding.InAppBiddingInterstitialTests"/>
+			<class name="appium.inAppBidding.InAppBiddingBannerTests"/>
+			<class name="appium.inAppBidding.InAppBiddingMraidTests"/>
+			<class name="appium.inAppBidding.InAppBiddingVideoTests"/>
+		</classes>
+	</test>
 </suite>

--- a/src/test/resources/appium/inAppBidding_requests/android/inApp_auction_300x250.json
+++ b/src/test/resources/appium/inAppBidding_requests/android/inApp_auction_300x250.json
@@ -25,6 +25,9 @@
         "prebid": {
           "storedrequest": {
             "id": "$VARIABLE"
+          },
+          "storedauctionresponse": {
+            "id": "$VARIABLE"
           }
         }
       }
@@ -84,6 +87,8 @@
   "ext": {
     "prebid": {
       "storedrequest": {
+        "id": "$VARIABLE"
+      },"storedauctionresponse": {
         "id": "$VARIABLE"
       },
       "cache": {

--- a/src/test/resources/appium/inAppBidding_requests/android/inApp_auction_320x50.json
+++ b/src/test/resources/appium/inAppBidding_requests/android/inApp_auction_320x50.json
@@ -25,6 +25,8 @@
         "prebid": {
           "storedrequest": {
             "id": "$VARIABLE"
+          },"storedauctionresponse": {
+            "id": "$VARIABLE"
           }
         }
       }
@@ -84,6 +86,8 @@
   "ext": {
     "prebid": {
       "storedrequest": {
+        "id": "$VARIABLE"
+      },"storedauctionresponse": {
         "id": "$VARIABLE"
       },
       "cache": {

--- a/src/test/resources/appium/inAppBidding_requests/android/inApp_auction_728x90.json
+++ b/src/test/resources/appium/inAppBidding_requests/android/inApp_auction_728x90.json
@@ -25,6 +25,8 @@
         "prebid": {
           "storedrequest": {
             "id": "$VARIABLE"
+          },"storedauctionresponse": {
+            "id": "$VARIABLE"
           }
         }
       }
@@ -84,6 +86,8 @@
   "ext": {
     "prebid": {
       "storedrequest": {
+        "id": "$VARIABLE"
+      },"storedauctionresponse": {
         "id": "$VARIABLE"
       },
       "cache": {

--- a/src/test/resources/appium/inAppBidding_requests/android/inApp_auction_ms.json
+++ b/src/test/resources/appium/inAppBidding_requests/android/inApp_auction_ms.json
@@ -29,6 +29,8 @@
         "prebid": {
           "storedrequest": {
             "id": "$VARIABLE"
+          },"storedauctionresponse": {
+            "id": "$VARIABLE"
           }
         }
       }
@@ -88,6 +90,8 @@
   "ext": {
     "prebid": {
       "storedrequest": {
+        "id": "$VARIABLE"
+      },"storedauctionresponse": {
         "id": "$VARIABLE"
       },
       "cache": {


### PR DESCRIPTION
* Changed connection type for mock request tests and smock tests
* Replaced logValidator for checking mock events with bmp getHar()